### PR TITLE
Add support for generator model quantization

### DIFF
--- a/anonipy/utils/package.py
+++ b/anonipy/utils/package.py
@@ -1,0 +1,34 @@
+from importlib.metadata import requires
+from typing import Union
+
+
+def is_installed_with(extra: Union[str, list[str]]) -> bool:
+    """Check if anonipy was installed with specific optional dependencies.
+
+    Args:
+        extra: The optional dependency or list of dependencies to check.
+            Valid values are: 'dev', 'test', 'quant', 'all'
+
+    Returns:
+        True if package was installed with the specified optional dependencies,
+            False otherwise.
+
+    Example:
+        >>> from anonipy.utils.package import is_installed_with
+        >>> is_installed_with('dev')  # check if dev dependencies are installed
+        >>> is_installed_with(['dev', 'test'])  # check multiple dependency groups
+    """
+    if isinstance(extra, str):
+        extra = [extra]
+
+    try:
+        package_requires = requires("anonipy") or []
+        installed_extras = set()
+
+        for req in package_requires:
+            if "extra == " in req:
+                installed_extras.add(req.split("extra == ")[1].strip("\"'"))
+
+        return any(e in installed_extras for e in extra)
+    except Exception:
+        return False

--- a/docs/how-to-guides/posts/generators-overview.md
+++ b/docs/how-to-guides/posts/generators-overview.md
@@ -83,7 +83,15 @@ The [LLMLabelGenerator][anonipy.anonymize.generators.LLMLabelGenerator] is a one
 from anonipy.anonymize.generators import LLMLabelGenerator
 ```
 
-The `LLMLabelGenerator` currently does not require any input parameters at initialization.
+The `LLMLabelGenerator` requires the following input parameters at initialization:
+
+::: anonipy.anonymize.generators.LLMLabelGenerator.__init__
+    options:
+        show_root_heading: False
+        show_docstring_description: False
+        show_docstring_examples: False
+        show_docstring_returns: False
+        show_source: False
 
 Let us now initialize the LLM label generator.
 
@@ -92,7 +100,7 @@ llm_generator = LLMLabelGenerator()
 ```
 
 !!! info "Initialization warnings"
-The initialization of `LLMLabelGenerator` will throw some warnings. Ignore them. These are expected due to the use of package dependencies.
+    The initialization of `LLMLabelGenerator` will throw some warnings. Ignore them. These are expected due to the use of package dependencies.
 
 To use the generator, we can call the `generate` method. The `generate` method receives the following parameters:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,10 @@ test = [
     "pytest",
     "pytest-cov",
 ]
-all = ["anonipy[dev,test]"]
+quant = [
+    "bitsandbytes",
+]
+all = ["anonipy[dev,test,quant]"]
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # NLP and LLMs
 spacy==3.8.2
-gliner==0.2.13
+gliner==0.2.16
 gliner-spacy==0.0.10
 transformers==4.45.2
 accelerate>=0.26.0

--- a/test/test_extractors.py
+++ b/test/test_extractors.py
@@ -171,7 +171,7 @@ TEST_PATTERN_DETECT_REPEATS = [
         start_index=86,
         end_index=96,
         type="date",
-        regex=r"Date of Examination: (.*)"
+        regex=r"Date of Examination: (.*)",
     ),
     # Repeated entity
     Entity(
@@ -180,7 +180,7 @@ TEST_PATTERN_DETECT_REPEATS = [
         start_index=759,
         end_index=769,
         type="date",
-        regex=r"Date of Examination: (.*)"
+        regex=r"Date of Examination: (.*)",
     ),
 ]
 TEST_MULTI_REPEATS = [
@@ -223,6 +223,7 @@ TEST_MULTI_REPEATS = [
         type="string",
     ),
 ]
+
 
 @pytest.fixture(autouse=True)
 def suppress_warnings():
@@ -270,7 +271,7 @@ def pattern_extractor():
                     {"SHAPE": "dddd"},
                 ]
             ],
-        }
+        },
     ]
     return PatternExtractor(labels=labels, lang=LANGUAGES.ENGLISH)
 
@@ -412,6 +413,7 @@ def test_pattern_extractor_extract_default(pattern_extractor):
         assert p_entity.regex == t_entity.regex
         assert p_entity.score == 1.0
 
+
 def test_pattern_extractor_detect_repeats_false():
     extractor = PatternExtractor(
         labels=[
@@ -434,6 +436,7 @@ def test_pattern_extractor_detect_repeats_false():
     assert excepted_entity.regex == entities[0].regex
     assert excepted_entity.score >= 0.5
 
+
 def test_pattern_extractor_detect_repeats_true():
     extractor = PatternExtractor(
         labels=[
@@ -454,6 +457,7 @@ def test_pattern_extractor_detect_repeats_true():
         assert p_entity.type == t_entity.type
         assert p_entity.regex == t_entity.regex
         assert p_entity.score >= 0.5
+
 
 def test_multi_extractor_init():
     with pytest.raises(TypeError):
@@ -568,16 +572,21 @@ def test_multi_extractor_extract_single_extractor_pattern(multi_extractor):
 
 def test_multi_extractor_detect_repeats_false():
     extractors = [
-        NERExtractor(labels=[
-            {"label": "name", "type": "string"},
-        ]), 
-        PatternExtractor(labels=[
-            {
-                "label": "date",
-                "type": "date",
-                "regex": r"Date of Examination: (.*)",
-            },
-        ])]
+        NERExtractor(
+            labels=[
+                {"label": "name", "type": "string"},
+            ]
+        ),
+        PatternExtractor(
+            labels=[
+                {
+                    "label": "date",
+                    "type": "date",
+                    "regex": r"Date of Examination: (.*)",
+                },
+            ]
+        ),
+    ]
     extractor = MultiExtractor(extractors)
     _, joint_entities = extractor(TEST_ORIGINAL_TEXT, detect_repeats=False)
     for p_entity, t_entity in zip(joint_entities, TEST_MULTI_REPEATS[:3]):
@@ -592,16 +601,21 @@ def test_multi_extractor_detect_repeats_false():
 
 def test_multi_extractor_detect_repeats_true():
     extractors = [
-        NERExtractor(labels=[
-            {"label": "name", "type": "string"},
-        ]), 
-        PatternExtractor(labels=[
-            {
-                "label": "date",
-                "type": "date",
-                "regex": r"Date of Examination: (.*)",
-            },
-        ])]
+        NERExtractor(
+            labels=[
+                {"label": "name", "type": "string"},
+            ]
+        ),
+        PatternExtractor(
+            labels=[
+                {
+                    "label": "date",
+                    "type": "date",
+                    "regex": r"Date of Examination: (.*)",
+                },
+            ]
+        ),
+    ]
     extractor = MultiExtractor(extractors)
     _, joint_entities = extractor(TEST_ORIGINAL_TEXT, detect_repeats=True)
     for p_entity, t_entity in zip(joint_entities, TEST_MULTI_REPEATS):


### PR DESCRIPTION
This pull request adds the option to load the `LLMLabelGenerator` in quantized mode. This allows for loading bigger models on the GPU by reducing their size and using bigger and better models to generate entity substitutions.