### PR TITLE
Fix the documentation and values for the Slovenian language

### DIFF
--- a/anonipy/constants.py
+++ b/anonipy/constants.py
@@ -24,7 +24,7 @@ class LANGUAGES:
         GERMAN (Tuple[Literal["de"], Literal["German"]]): The German language.
         GREEK (Tuple[Literal["el"], Literal["Greek"]]): The Greek language.
         ITALIAN (Tuple[Literal["it"], Literal["Italian"]]): The Italian language.
-        SLOVENE (Tuple[Literal["sl"], Literal["Slovene"]]): The Slovene language.
+        SLOVENIAN (Tuple[Literal["sl"], Literal["Slovenian"]]): The Slovenian language.
         SPANISH (Tuple[Literal["es"], Literal["Spanish"]]): The Spanish language.
         UKRAINIAN (Tuple[Literal["uk"], Literal["Ukrainian"]]): The Ukrainian language.
 
@@ -40,7 +40,7 @@ class LANGUAGES:
     GERMAN = ("de", "German")
     GREEK = ("el", "Greek")
     ITALIAN = ("it", "Italian")
-    SLOVENE = ("sl", "Slovene")
+    SLOVENIAN = ("sl", "Slovenian")
     SPANISH = ("es", "Spanish")
     UKRAINIAN = ("uk", "Ukrainian")
 

--- a/anonipy/utils/regex.py
+++ b/anonipy/utils/regex.py
@@ -82,7 +82,7 @@ REGEX_DATE = (
     r"(\d{1,2}°?[ ](gen|feb|mar|apr|mag|giu|lug|ago|set|ott|nov|dic)[\.]?[ ]\d{4}(?:[ ]?\d{2}:\d{2}(?::\d{2})?)?)|"
     r"([A-Za-zÀ-ÿ]+,?[ ]\d{1,2}°?[ ](gennaio|febbraio|marzo|aprile|maggio|giugno|luglio|agosto|settembre|ottobre|novembre|dicembre),?[ ]\d{4}(?:[ ]?\d{2}:\d{2}(?::\d{2})?)?)|"
     r"([A-Za-zÀ-ÿ]+,?[ ](gennaio|febbraio|marzo|aprile|maggio|giugno|luglio|agosto|settembre|ottobre|novembre|dicembre)[ ]\d{1,2}°?,?[ ]\d{4}(?:[ ]?\d{2}:\d{2}(?::\d{2})?)?)|"
-    # Slovene dates
+    # Slovenian dates
     r"(\d{1,2}[\.]?[ ](januar|februar|marec|april|maj|junij|julij|avgust|september|oktober|november|december)[ ]\d{4}(?:[ ]?\d{2}:\d{2}(?::\d{2})?)?)|"
     r"(\d{1,2}[\.]?[ ](januarja|februarja|marca|aprila|maja|junija|julija|avgusta|septembra|oktobra|novembra|decembra)[ ]\d{4}(?:[ ]?\d{2}:\d{2}(?::\d{2})?)?)|"
     r"(\d{1,2}[\.]?[ ](jan|feb|mar|apr|maj|jun|jul|avg|sep|okt|nov|dec)[\.]?[ ]\d{4}(?:[ ]?\d{2}:\d{2}(?::\d{2})?)?)|"

--- a/test/test_language_detector.py
+++ b/test/test_language_detector.py
@@ -39,11 +39,11 @@ def test_detect_english(language_detector):
     assert language == LANGUAGES.ENGLISH
 
 
-def test_detect_slovene(language_detector):
+def test_detect_slovenian(language_detector):
     language = language_detector.detect("Ta test preverja, ali metoda dela pravilno")
     assert language[0] == "sl"
-    assert language[1] == "Slovene"
-    assert language == LANGUAGES.SLOVENE
+    assert language[1] == "Slovenian"
+    assert language == LANGUAGES.SLOVENIAN
 
 
 def test_detect_german(language_detector):


### PR DESCRIPTION
This PR fixes the mismatch of using Slovene instead of Slovenian, because of which parts of the pipeline do not work. 