### PR TITLE
Change default gliner model used in NERExtractor

### DIFF
--- a/anonipy/anonymize/extractors/ner_extractor.py
+++ b/anonipy/anonymize/extractors/ner_extractor.py
@@ -62,7 +62,7 @@ class NERExtractor(ExtractorInterface):
         lang: LANGUAGES = LANGUAGES.ENGLISH,
         score_th: float = 0.5,
         use_gpu: bool = False,
-        gliner_model: str = "urchade/gliner_multi_pii-v1",
+        gliner_model: str = "E3-JSI/gliner-multi-pii-domains-v1",
         spacy_style: str = "ent",
         **kwargs,
     ):

--- a/anonipy/definitions.py
+++ b/anonipy/definitions.py
@@ -61,6 +61,14 @@ class Entity:
         p_match = re.match(r"^.*?\((.*)\).*$", self.regex)
         return p_match.group(1) if p_match else self.regex
 
+    def __str__(self) -> str:
+        """String representation of the entity.
+
+        Returns:
+            The string representation of the entity.
+
+        """
+        return f"Entity(text='{self.text}', label='{self.label}', start_index={self.start_index}, end_index={self.end_index}, type='{self.type}')"
 
 class Replacement(TypedDict):
     """The class representing the anonipy Replacement object.

--- a/test/test_extractors.py
+++ b/test/test_extractors.py
@@ -499,7 +499,7 @@ def test_multi_extractor_extract_default(multi_extractor):
     # check the performance of the joint entities generation
     for p_entity, t_entity in zip(
         joint_entities,
-        filter_entities(TEST_NER_ENTITIES + TEST_PATTERN_ENTITIES),
+        filter_entities(TEST_NER_ENTITIES + TEST_REPEATS_ENTITIES + TEST_PATTERN_ENTITIES),
     ):
         assert p_entity.text == t_entity.text
         assert p_entity.label == t_entity.label


### PR DESCRIPTION
This PR changes the default gliner model used in NERExtractor from `urchade/gliner_multi_pii-v1` to `E3-JSI/gliner-multi-pii-domains-v1`. 

The newer model was trained on [E3-JSI/synthetic-multi-pii-ner-v1](https://huggingface.co/datasets/E3-JSI/synthetic-multi-pii-ner-v1), a synthetic dataset that covers different languages. Furthermore, the model was fine-tuned from `urchade/gliner_multi_pii-v1`.